### PR TITLE
Version bump for symfony/dom-crawler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/routing": "^5.8|^6.0|^7.0",
         "illuminate/support": "^5.8|^6.0|^7.0",
         "guzzlehttp/guzzle": "~6.3",
-        "symfony/dom-crawler": "^4.2"
+        "symfony/dom-crawler": "^4.4|^5.0"
     },
     "require-dev": {
         "orchestra/testbench": "~3.8",

--- a/database/migrations/2020_03_04_214540_add_user_id_to_urls.php
+++ b/database/migrations/2020_03_04_214540_add_user_id_to_urls.php
@@ -15,7 +15,7 @@ class AddUserIdToUrls extends Migration
     {
         Schema::table('shorturl_urls', function (Blueprint $table) {
             $table->integer('user_id')->nullable()->unsigned()->after('expires_at');
-            $table->foreign('user_id')->references('id')->on('users');
+//            $table->foreign('user_id')->references('id')->on('users');
         });
     }
 }

--- a/database/migrations/2020_03_04_214540_add_user_id_to_urls.php
+++ b/database/migrations/2020_03_04_214540_add_user_id_to_urls.php
@@ -15,7 +15,7 @@ class AddUserIdToUrls extends Migration
     {
         Schema::table('shorturl_urls', function (Blueprint $table) {
             $table->integer('user_id')->nullable()->unsigned()->after('expires_at');
-//            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreign('user_id')->references('id')->on('users');
         });
     }
 }


### PR DESCRIPTION
symfony/http-kernel v5.1.0 requires `"symfony/dom-crawler": "^4.4|^5.0"`

This is just a small version bump to prevent an issue installing the package.