### PR TITLE
Allow custom migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Instead of adding ``` ShortUrl::routes(); ``` you can call three separates metho
 
 this allows you to add middlewares or prefix routes.
 
+### Migration Customization
+
+If you are not going to use Short Url's default migrations, you should call the
+`ShortUrl::ignoreMigrations();`  method in the `register` method of your `AppServiceProvider`.
+You may export the default migrations using
+
+```
+php artisan vendor:publish --tag=shorturl-migrations
+```
+
 ## Nice!
 
 Laravel short url is now set up on your homepage.

--- a/src/ShortUrl.php
+++ b/src/ShortUrl.php
@@ -5,6 +5,13 @@ namespace Gallib\ShortUrl;
 class ShortUrl
 {
     /**
+     * Indicates if migrations will be run.
+     *
+     * @var bool
+     */
+    public static $runsMigrations = true;
+
+    /**
      * Register the routes to create urls.
      *
      * @return void
@@ -48,5 +55,15 @@ class ShortUrl
         $this->createRoutes();
         $this->manageRoutes();
         $this->redirectRoute();
+    }
+
+    /**
+     * Configure package to not register its migrations.
+     *
+     * @return static
+     */
+    public static function ignoreMigrations()
+    {
+        static::$runsMigrations = false;
     }
 }

--- a/src/ShortUrlServiceProvider.php
+++ b/src/ShortUrlServiceProvider.php
@@ -18,7 +18,11 @@ class ShortUrlServiceProvider extends ServiceProvider
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'shorturl');
 
         if ($this->app->runningInConsole()) {
-            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+            $this->registerMigrations();
+
+            $this->publishes([
+                __DIR__.'/../database/migrations' => database_path('migrations'),
+            ], 'shorturl-migrations');
 
             $this->publishes([
                 __DIR__.'/../config/shorturl.php' => config_path('shorturl.php'),
@@ -31,6 +35,18 @@ class ShortUrlServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../assets' => public_path('gallib/shorturl'),
             ], 'shorturl-assets');
+        }
+    }
+
+    /**
+     * Register migration files.
+     *
+     * @return void
+     */
+    protected function registerMigrations()
+    {
+        if (ShortUrl::$runsMigrations) {
+            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         }
     }
 


### PR DESCRIPTION
I had an issue with the mysql limit for key size (laravel/laravel#4774), but could not change the default size. Then I had to disable auto discover and replace the service provider.

Laravel's Passport allows the use of custom migrations and I used the same approach.

Also I assume it would fix PR #23 problems.

